### PR TITLE
Fix 70: Role Urls in Tokens should be kept unchanged upon creating / parsing tokens.

### DIFF
--- a/src/main/java/io/personium/common/auth/token/AbstractOAuth2Token.java
+++ b/src/main/java/io/personium/common/auth/token/AbstractOAuth2Token.java
@@ -19,7 +19,6 @@
 package io.personium.common.auth.token;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -219,29 +218,50 @@ public abstract class AbstractOAuth2Token {
         this.roleList.add(role);
     }
 
-    final String makeRolesString() {
+    final String makeRoleClassUrlListString() {
         if (this.roleList == null || this.roleList.size() == 0) {
             return null;
         }
         StringBuilder sb = new StringBuilder();
         for (Role rl : this.roleList) {
-            sb.append(rl.createUrl());
+            sb.append(rl.toRoleClassURL());
+            sb.append(" ");
+        }
+        return sb.substring(0, sb.length() - 1);
+    }
+    final String makeRoleInstanceUrlListString() {
+        if (this.roleList == null || this.roleList.size() == 0) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Role rl : this.roleList) {
+            sb.append(rl.toRoleInstanceURL());
             sb.append(" ");
         }
         return sb.substring(0, sb.length() - 1);
     }
 
-    static List<Role> parseRolesString(final String rolesStr) throws MalformedURLException {
+
+    static List<Role> parseSpaceSeparatedRoleClassUrlString(final String rolesStr) throws MalformedURLException {
         List<Role> ret = new ArrayList<Role>();
         if ("".equals(rolesStr)) {
             return ret;
         }
         for (String s : rolesStr.split(" ")) {
-            ret.add(new Role(new URL(s)));
+            ret.add(Role.createFromRoleClassUrl(s));
         }
         return ret;
     }
-
+    static List<Role> parseSpaceSeparatedRoleInstanceUrlString(final String rolesStr) throws MalformedURLException {
+        List<Role> ret = new ArrayList<Role>();
+        if ("".equals(rolesStr)) {
+            return ret;
+        }
+        for (String s : rolesStr.split(" ")) {
+            ret.add(Role.createFromRoleInstanceUrl(s));
+        }
+        return ret;
+    }
     static final TokenParseException PARSE_EXCEPTION = new TokenParseException("failed to parse token");
 
     /**
@@ -334,4 +354,7 @@ public abstract class AbstractOAuth2Token {
         }
         return map.toString();
     }
+    String makeRolesString() {
+        return "";
+    };
 }

--- a/src/main/java/io/personium/common/auth/token/AbstractOAuth2Token.java
+++ b/src/main/java/io/personium/common/auth/token/AbstractOAuth2Token.java
@@ -211,7 +211,7 @@ public abstract class AbstractOAuth2Token {
      * returns Role List.
      * @return Role list
      */
-    public final List<Role> getRoles() {
+    public final List<Role> getRoleList() {
         return this.roleList;
     }
 

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -23,38 +23,38 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Roleの定義体.
+ * model of the Role in Personium.
  */
 public class Role {
     /**
-     * Edm EntityType名.
+     * Edm EntityType Name.
      */
     public static final String EDM_TYPE_NAME = "Role";
 
     /**
-     * ロールの名称.
+     * Role Name.
      */
     private String name;
     /**
-     * ロールの属するボックスオブジェクト.
+     * Name of the box, if any, which this box is bound to.
      */
     private String boxName;
     /**
-     * ロールの属するボックスのSchema.
+     * Schema Uri of the box, if any, which this box is bound to.
      */
     private String boxSchema;
     /**
-     * ロールリソースのベースURL.
+     * Cell URL of the role resource corresponding to this role.
      */
     private String baseUrl;
 
     /**
-     * コンストラクタ.
-     * @param url ロールリソースのURL
-     * @throws MalformedURLException URLが不正な場合に発生
+     * Constructor.
+     * @param url Role Resource URL
+     * @throws MalformedURLException if URL is malformed
      */
     public Role(URL url) throws MalformedURLException {
-        // ロールリソースのURL↓
+        // Role Resource URL looks like this.
         // https://localhost:8080/dc1-core/testcell1/__role/box1/rolename
         Pattern pattern = Pattern.compile("(.+/)__role/([^/]+)/(.+)");
         Matcher matcher = pattern.matcher(url.toString());
@@ -68,10 +68,10 @@ public class Role {
 
     /**
      * Constructor.
-     * @param name ロール名.
-     * @param boxName ロールの属するボックス名.
-     * @param boxSchema ロールの属するボックスのSchema
-     * @param baseUrl ロールの属するセルのURL
+     * @param name Role Name.
+     * @param boxName Name of the box this role is bound to.
+     * @param boxSchema Schema URI of the box  this role is bound to.
+     * @param baseUrl Cell URL of this role
      */
     public Role(final String name, final String boxName, final String boxSchema, final String baseUrl) {
         this.name = name;
@@ -99,17 +99,17 @@ public class Role {
     }
 
     /**
-     * スキーマ用ロールリソースのURLを返す.
+     * Returns Role instance URL for this role.
      * @param url ロールリソースのベースURL
-     * @return String ロールリソースのURL
+     * @return Role instance URL.
      */
     public String schemeCreateUrl(String url) {
-        // ロールに紐付くBox判断
+        // Roleに紐付くBox判断
         String boxName2 = null;
         if (this.boxName != null) {
             boxName2 = this.boxName;
         } else {
-            // 紐付かない場合、use main box name.
+            // If not bound to any box, then use main box name.
             boxName2 = MAIN_BOX_NAME;
         }
         String url3 = createBaseUrl(url);
@@ -135,7 +135,7 @@ public class Role {
         String url2 = null;
         if (this.boxName != null && this.boxSchema != null && !"null".equals(this.boxSchema)) {
             // BOXに紐付いている場合BOXに設定されているスキーマURLをBaseURLに使う
-            // なお、BOXにスキーマURLが設定されていない場合は設定ミスの可能性があるので紐付いていないとみなす。
+            // aなお、BOXにスキーマURLが設定されていない場合は設定ミスの可能性があるので紐付いていないとみなす。
             url2 = this.boxSchema;
         } else {
             // BOXに紐付いていない場合ISSUERをBaseURLに使う
@@ -174,32 +174,32 @@ public class Role {
     }
 
     /**
-     * ロール名を取得する.
-     * @return name ロール名
+     * gets the name of this role.
+     * @return Role Name
      */
     public String getName() {
         return name;
     }
 
     /**
-     * 属するボックス名を取得する.
-     * @return boxName ボックス名.
+     * gets the name of the box this role is bound to.
+     * @return Name of the box this role is bound to.
      */
     public String getBoxName() {
         return boxName;
     }
 
     /**
-     * 属するボックスのスキーマ名を取得する.
-     * @return boxSchema スキーマ名.
+     * gets the schema uri of the box this role is bound to.
+     * @return schema uri of the box this role is bound to.
      */
     public String getBoxSchema() {
         return boxSchema;
     }
 
     /**
-     * 属するBaseUrlを取得する.
-     * @return baseUrl ベースURL.
+     * gets the Base Url of the role.
+     * @return base Url of the role.
      */
     public String getBaseUrl() {
         return baseUrl;
@@ -210,11 +210,11 @@ public class Role {
     private static final int INDEX_ROLE_URL_BOX_NAME = 2;
     private static final int INDEX_ROLE_URL_ROLE_NAME = 3;
     /**
-     * RoleリソースURLフォーマット.
+     * Role Resource URL format.
      */
     public static final String ROLE_RESOURCE_FORMAT = "%s/__role/%s/%s";
     /**
-     * デフォルトボックス名.
+     * Main Box Name.
      */
     public static final String MAIN_BOX_NAME = "__";
 

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2014-2018 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2019 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +66,12 @@ public class Role {
         this.boxName = matcher.group(INDEX_ROLE_URL_BOX_NAME);
         this.baseUrl = matcher.group(INDEX_ROLE_URL_BASE);
     }
+    /**
+     * create a Role from role class url.
+     * @param roleClassUrl
+     * @return
+     * @throws MalformedURLException
+     */
     public static Role createFromRoleClassUrl(String roleClassUrl) throws MalformedURLException {
         Pattern pattern = Pattern.compile("(.+/)__role/([^/]+)/(.+)");
         Matcher matcher = pattern.matcher(roleClassUrl);
@@ -77,8 +84,15 @@ public class Role {
         if (!MAIN_BOX_NAME.equals(boxName)) {
             throw new MalformedURLException("This is not a role class url. [" + roleClassUrl + "]");
         }
-        return new Role(name, boxName, baseUrl, baseUrl); 
+        return new Role(name, boxName, baseUrl, baseUrl);
     }
+    /**
+     * create a Role from role instance url.
+     * note that the box schema information can not be automatically poplulated in this method.
+     * @param roleClassUrl
+     * @return
+     * @throws MalformedURLException
+     */
     public static Role createFromRoleInstanceUrl(String roleInstanceUrl) throws MalformedURLException {
         Pattern pattern = Pattern.compile("(.+/)__role/([^/]+)/(.+)");
         Matcher matcher = pattern.matcher(roleInstanceUrl);
@@ -88,7 +102,7 @@ public class Role {
         String name = matcher.group(INDEX_ROLE_URL_ROLE_NAME);
         String boxName = matcher.group(INDEX_ROLE_URL_BOX_NAME);
         String baseUrl = matcher.group(INDEX_ROLE_URL_BASE);
-        return new Role(name, boxName, baseUrl, baseUrl); 
+        return new Role(name, boxName, null, baseUrl);
     }
 
     /**

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -65,6 +65,31 @@ public class Role {
         this.boxName = matcher.group(INDEX_ROLE_URL_BOX_NAME);
         this.baseUrl = matcher.group(INDEX_ROLE_URL_BASE);
     }
+    public static Role createFromRoleClassUrl(String roleClassUrl) throws MalformedURLException {
+        Pattern pattern = Pattern.compile("(.+/)__role/([^/]+)/(.+)");
+        Matcher matcher = pattern.matcher(roleClassUrl);
+        if (!matcher.find()) {
+            throw new MalformedURLException("This is not a role class url. [" + roleClassUrl + "]");
+        }
+        String name = matcher.group(INDEX_ROLE_URL_ROLE_NAME);
+        String boxName = matcher.group(INDEX_ROLE_URL_BOX_NAME);
+        String baseUrl = matcher.group(INDEX_ROLE_URL_BASE);
+        if (!MAIN_BOX_NAME.equals(boxName)) {
+            throw new MalformedURLException("This is not a role class url. [" + roleClassUrl + "]");
+        }
+        return new Role(name, boxName, baseUrl, baseUrl); 
+    }
+    public static Role createFromRoleInstanceUrl(String roleInstanceUrl) throws MalformedURLException {
+        Pattern pattern = Pattern.compile("(.+/)__role/([^/]+)/(.+)");
+        Matcher matcher = pattern.matcher(roleInstanceUrl);
+        if (!matcher.find()) {
+            throw new MalformedURLException("This is not a role instance url. [" + roleInstanceUrl + "]");
+        }
+        String name = matcher.group(INDEX_ROLE_URL_ROLE_NAME);
+        String boxName = matcher.group(INDEX_ROLE_URL_BOX_NAME);
+        String baseUrl = matcher.group(INDEX_ROLE_URL_BASE);
+        return new Role(name, boxName, baseUrl, baseUrl); 
+    }
 
     /**
      * Constructor.

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * model of the Role in Personium.
+ * Model of the Role in Personium.
  */
 public class Role {
     /**
@@ -53,6 +53,7 @@ public class Role {
      * Constructor.
      * @param url Role Resource URL
      * @throws MalformedURLException if URL is malformed
+     * @deprecated
      */
     public Role(URL url) throws MalformedURLException {
         // Role Resource URL looks like this.
@@ -121,6 +122,7 @@ public class Role {
 
     /**
      * Constructor for test.
+     * @deprecated
      * @param name role name.
      */
     public Role(final String name) {
@@ -139,7 +141,8 @@ public class Role {
 
     /**
      * Returns Role instance URL for this role.
-     * @param url ロールリソースのベースURL
+     * @deprecated
+     * @param url base URL of role resource
      * @return Role instance URL.
      */
     public String schemeCreateUrl(String url) {
@@ -157,16 +160,53 @@ public class Role {
 
     /**
      * Returns Role class URL.
-     * @param url ロールリソースのベースURL
+     * @deprecated
+     * @param url base URL of role resource
      * @return String Role resource URL
      */
     public String schemeCreateUrlForTranceCellToken(String url) {
-        String url3 = createBaseUrl(url);
-        return String.format(ROLE_RESOURCE_FORMAT, url3, MAIN_BOX_NAME, this.name);
+        return this.toRoleClassURL();
     }
-
+    /**
+     * Returns Role class URL.
+     * @param url base URL of role resource
+     * @return String Role class URL
+     */
+    public String toRoleClassURL() {
+        if (this.boxSchema != null) {
+            return String.format(ROLE_RESOURCE_FORMAT, this.boxSchema, MAIN_BOX_NAME, this.name);
+        }
+        if (MAIN_BOX_NAME.equals(this.boxName) || this.boxName == null) {
+            if (this.baseUrl == null) {
+                throw new RuntimeException("Cannot create role class url since baseUrl is null for boxName = main");
+            }
+            return String.format(ROLE_RESOURCE_FORMAT, this.baseUrl, MAIN_BOX_NAME, this.name);
+        }
+        throw new RuntimeException("Cannot create role class url when boxSchema is null and non-main boxName is given.");
+    }
+    /**
+     * Returns Role Instance URL.
+     * @param url base URL of role resource
+     * @return String Role instance URL
+     */
+    public String toRoleInstanceURL() {
+        if (this.baseUrl == null) {
+            throw new RuntimeException("Cannot create role instance url without baseUrl.");
+        }
+        if (this.boxName == null) {
+            if (this.boxSchema != null) {
+                throw new RuntimeException("Illegal State. box schema is given but box name is null ");
+            }
+            return String.format(ROLE_RESOURCE_FORMAT, this.baseUrl, MAIN_BOX_NAME, this.name);
+        }
+        if (this.boxSchema == null) {
+            return String.format(ROLE_RESOURCE_FORMAT, this.baseUrl, MAIN_BOX_NAME, this.name);
+        }
+        return String.format(ROLE_RESOURCE_FORMAT, this.baseUrl, this.boxName, this.name);
+    }
     /**
      * BaseURLを作成する.
+     * @deprecated
      * @param url ロールリソースのベースURL
      * @return String ロールのベースURL
      */
@@ -186,6 +226,7 @@ public class Role {
     }
 
     /**
+     * @deprecated
      * ローカル用ロールリソースのURLを返す.
      * @param url ロールリソースのベースURL
      * @return String ロールリソースのURL
@@ -205,6 +246,7 @@ public class Role {
     }
 
     /**
+     * @deprecated
      * ロールリソースのURLを返す.
      * @return String ロールリソースのURL
      */
@@ -251,10 +293,9 @@ public class Role {
     /**
      * Role Resource URL format.
      */
-    public static final String ROLE_RESOURCE_FORMAT = "%s/__role/%s/%s";
+    public static final String ROLE_RESOURCE_FORMAT = "%s__role/%s/%s";
     /**
      * Main Box Name.
      */
     public static final String MAIN_BOX_NAME = "__";
-
 }

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -147,25 +147,6 @@ public class Role {
     }
 
     /**
-     * ローカル用ロールリソースのURLを返す.
-     * @param url ロールリソースのベースURL
-     * @return String ロールリソースのURL
-     */
-    public String localCreateUrl(String url) {
-        // ロールに紐付くBox判断
-        String boxName2 = null;
-        if (this.boxName != null) {
-            boxName2 = this.boxName;
-        } else {
-            // 紐付かない場合、デフォルトボックス名を使用する
-            boxName2 = MAIN_BOX_NAME;
-        }
-        // 連結でスラッシュつけてるので、URLの最後がスラッシュだったら消す。
-        String url3 = url.replaceFirst("/$", "");
-        return String.format(ROLE_RESOURCE_FORMAT, url3, boxName2, this.name);
-    }
-
-    /**
      * ロールリソースのURLを返す.
      * @return String ロールリソースのURL
      */

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -160,7 +160,7 @@ public class Role {
         String url2 = null;
         if (this.boxName != null && this.boxSchema != null && !"null".equals(this.boxSchema)) {
             // BOXに紐付いている場合BOXに設定されているスキーマURLをBaseURLに使う
-            // aなお、BOXにスキーマURLが設定されていない場合は設定ミスの可能性があるので紐付いていないとみなす。
+            // なお、BOXにスキーマURLが設定されていない場合は設定ミスの可能性があるので紐付いていないとみなす。
             url2 = this.boxSchema;
         } else {
             // BOXに紐付いていない場合ISSUERをBaseURLに使う

--- a/src/main/java/io/personium/common/auth/token/Role.java
+++ b/src/main/java/io/personium/common/auth/token/Role.java
@@ -172,6 +172,25 @@ public class Role {
     }
 
     /**
+     * ローカル用ロールリソースのURLを返す.
+     * @param url ロールリソースのベースURL
+     * @return String ロールリソースのURL
+     */
+    public String localCreateUrl(String url) {
+        // ロールに紐付くBox判断
+        String boxName2 = null;
+        if (this.boxName != null) {
+            boxName2 = this.boxName;
+        } else {
+            // 紐付かない場合、デフォルトボックス名を使用する
+            boxName2 = MAIN_BOX_NAME;
+        }
+        // 連結でスラッシュつけてるので、URLの最後がスラッシュだったら消す。
+        String url3 = url.replaceFirst("/$", "");
+        return String.format(ROLE_RESOURCE_FORMAT, url3, boxName2, this.name);
+    }
+
+    /**
      * ロールリソースのURLを返す.
      * @return String ロールリソースのURL
      */

--- a/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
+++ b/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
@@ -356,7 +356,7 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
                 //attr.setPrefix("xsi");
                 //attr.setValue("string");
                 //attrValue.setAttributeNodeNS(attr);
-                attrValue.setTextContent(role.schemeCreateUrlForTranceCellToken(this.issuer));
+                attrValue.setTextContent(role.toRoleClassURL());
                 attributeRoles.appendChild(attrValue);
             }
         }

--- a/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
+++ b/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
@@ -689,10 +689,6 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
         return this.getIssuer();
     }
 
-    @Override
-    public List<Role> getRoleList() {
-        return this.getRoles();
-    }
 
     @Override
     public String getCookieString(String cookiePeer, String issuer) {

--- a/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
+++ b/src/main/java/io/personium/common/auth/token/TransCellAccessToken.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -572,7 +571,7 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
         NodeList attrList = e.getElementsByTagName("AttributeValue");
         for (int i = 0; i < attrList.getLength(); i++) {
             Element attv = (Element) (attrList.item(i));
-            ret.add(new Role(new URL(attv.getTextContent())));
+            ret.add(Role.createFromRoleClassUrl(attv.getTextContent()));
         }
 
         return ret;
@@ -587,12 +586,17 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
         return ret;
     }
 
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTarget() {
         return this.target;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getId() {
         return this.id;
@@ -677,6 +681,9 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
 
 
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getExtCellUrl() {
         return this.getIssuer();
@@ -692,9 +699,11 @@ public final class TransCellAccessToken extends AbstractOAuth2Token implements I
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String[] getScope() {
         return this.scope;
     }
-
 }

--- a/src/main/java/io/personium/common/auth/token/VisitorLocalAccessToken.java
+++ b/src/main/java/io/personium/common/auth/token/VisitorLocalAccessToken.java
@@ -119,9 +119,5 @@ public class VisitorLocalAccessToken extends AbstractLocalAccessToken implements
         return this.issuer;
     }
 
-    @Override
-    public List<Role> getRoleList() {
-        return this.roleList;
-    }
 
 }

--- a/src/main/java/io/personium/common/auth/token/VisitorLocalAccessToken.java
+++ b/src/main/java/io/personium/common/auth/token/VisitorLocalAccessToken.java
@@ -96,7 +96,7 @@ public class VisitorLocalAccessToken extends AbstractLocalAccessToken implements
         VisitorLocalAccessToken ret = new VisitorLocalAccessToken();
         String[] ext = ret.populate(token.substring(PREFIX_ACCESS.length()), issuer, 1);
         try {
-            ret.roleList = AbstractOAuth2Token.parseRolesString(ext[0]);
+            ret.roleList = AbstractOAuth2Token.parseSpaceSeparatedRoleInstanceUrlString(ext[0]);
             return ret;
         } catch (MalformedURLException e) {
             throw new TokenParseException(e.getMessage(), e);
@@ -119,5 +119,9 @@ public class VisitorLocalAccessToken extends AbstractLocalAccessToken implements
         return this.issuer;
     }
 
+    @Override
+    String makeRolesString() {
+        return makeRoleInstanceUrlListString();
+    };
 
 }

--- a/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
+++ b/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
@@ -72,6 +72,7 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
      * @param origIssuer このRefreshToken発行の際に使われた、元のTransCell アクセストークンの発行者
      * @param origRoleList このRefreshToken発行の際に使われた、元のTransCell アクセストークンに書かれたロールリスト
      * @param schema クライアント認証されたデータスキーマ
+     * @param scope array of scopes
      */
     public VisitorRefreshToken(
             final String id,
@@ -90,14 +91,7 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     }
 
     /**
-     * 既定値の有効期間を設定してトークンを生成する.
-     * @param id トークンの一意識別子
-     * @param issuedAt 発行時刻(epochからのミリ秒)
-     * @param issuer 発行者URL
-     * @param subject アクセス主体URL
-     * @param origIssuer このRefreshToken発行の際に使われた、元のTransCell アクセストークンの発行者
-     * @param origRoleList このRefreshToken発行の際に使われた、元のTransCell アクセストークンに書かれたロールリスト
-     * @param schema クライアント認証されたデータスキーマ
+     * @deprecated use other constructor
      */
     public VisitorRefreshToken(
             final String id,
@@ -113,13 +107,7 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     }
 
     /**
-     * 既定値の有効期間を設定してトークンを生成する.
-     * @param id トークンの一意識別子
-     * @param issuer 発行者URL
-     * @param subject アクセス主体URL
-     * @param origIssuer このRefreshToken発行の際に使われた、元のTransCell アクセストークンの発行者
-     * @param origRoleList このRefreshToken発行の際に使われた、元のTransCell アクセストークンに書かれたロールリスト
-     * @param schema クライアント認証されたデータスキーマ
+     * @deprecated use other constructor
      */
     public VisitorRefreshToken(
             final String id,
@@ -141,11 +129,11 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     }
 
     /**
-     * トークン文字列をissuerで指定されたCellとしてパースする.
+     * parse the Token String,as an issuer Cell specified.
      * @param token Token String
      * @param issuer Cell Root URL
-     * @return パースされたCellLocalTokenオブジェクト
-     * @throws AbstractOAuth2Token.TokenParseException トークンのパースに失敗したとき投げられる例外
+     * @return VisitorRefreshToken object as a parse result
+     * @throws AbstractOAuth2Token.TokenParseException when failed to parse
      */
     public static VisitorRefreshToken parse(final String token, final String issuer)
             throws AbstractOAuth2Token.TokenParseException {
@@ -159,7 +147,8 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
             String[] extra = ret.populate(token.substring(PREFIX_TC_REFRESH.length()), issuer, 3);
             ret.id = extra[IDX_ID];
             ret.originalIssuer = extra[IDX_ORIG_ISSUER];
-            ret.roleList = AbstractOAuth2Token.parseRolesString(extra[IDX_ORIG_ROLE_LIST]);
+            // Role class url list is there in Visitor Refresh Tokens
+            ret.roleList = AbstractOAuth2Token.parseSpaceSeparatedRoleClassUrlString(extra[IDX_ORIG_ROLE_LIST]);
             return ret;
         } catch (MalformedURLException e) {
             throw AbstractOAuth2Token.PARSE_EXCEPTION;
@@ -173,6 +162,7 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
 
     /**
      * {@inheritDoc}
+     * @deprecated
      */
     @Override
     public IAccessToken refreshAccessToken(final long issuedAt, final String target, String url, List<Role> role) {
@@ -217,5 +207,11 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     public String getExtCellUrl() {
         return this.originalIssuer;
     }
-
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String makeRolesString() {
+        return makeRoleClassUrlListString();
+    };
 }

--- a/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
+++ b/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
@@ -209,7 +209,7 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     public IRefreshToken refreshRefreshToken(final long issuedAt, final long lifespan) {
         // TODO 本当は ROLEは再度読み直すべき。
         return new VisitorRefreshToken(UUID.randomUUID().toString(), issuedAt, lifespan, this.issuer, this.subject,
-                this.originalIssuer, this.getRoles(), this.schema, this.scope);
+                this.originalIssuer, this.getRoleList(), this.schema, this.scope);
     }
 
 
@@ -217,11 +217,5 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
     public String getExtCellUrl() {
         return this.originalIssuer;
     }
-
-    @Override
-    public List<Role> getRoleList() {
-        return this.getRoles();
-    }
-
 
 }

--- a/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
+++ b/src/main/java/io/personium/common/auth/token/VisitorRefreshToken.java
@@ -199,7 +199,6 @@ public final class VisitorRefreshToken extends AbstractLocalToken implements IRe
      */
     @Override
     public IRefreshToken refreshRefreshToken(final long issuedAt) {
-        // TODO 本当は ROLEは再度読み直すべき。
         return refreshRefreshToken(issuedAt, REFRESH_TOKEN_EXPIRES_MILLISECS);
     }
 

--- a/src/test/java/io/personium/common/auth/token/ResidentRefreshTokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/ResidentRefreshTokenTest.java
@@ -64,7 +64,7 @@ public class ResidentRefreshTokenTest {
         String target = "https://personium/targetcell/";
         String cellUrl = "https://personium/testcell/";
         List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
+        Role role = new Role("roleName", null, null, cellUrl);
         roleList.add(role);
 
         // --------------------
@@ -115,7 +115,7 @@ public class ResidentRefreshTokenTest {
         String target = null;
         String cellUrl = "https://personium/testcell02/";
         List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
+        Role role = new Role("roleName", null, null, cellUrl);
         roleList.add(role);
 
         // --------------------
@@ -174,7 +174,7 @@ public class ResidentRefreshTokenTest {
         String target = "https://personium/targetcell/";
         String cellUrl = "https://personium/testcell02/";
         List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
+        Role role = new Role("roleName", null, null, cellUrl);
         roleList.add(role);
 
         // --------------------

--- a/src/test/java/io/personium/common/auth/token/RoleTest.java
+++ b/src/test/java/io/personium/common/auth/token/RoleTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+
 import org.junit.Test;
 
 /**
@@ -29,41 +29,39 @@ import org.junit.Test;
 public class RoleTest {
 
     /**
-     * Roleのコンストラクタのテスト.
-     * @throws MalformedURLException URLパースエラー
+     * test for createFromRoleClassUrl normal usage.
+     * @throws MalformedURLException
      */
     @Test
-    public void testRoleConstruct() throws MalformedURLException {
+    public void createFromRoleClassUrl_normal() throws MalformedURLException {
         String baseUrl = "https://localhost:8080/personium-core/testcell1/";
         String roleUrl = "__role/__/role1";
-        URL url = new URL(baseUrl + roleUrl);
-        Role role = new Role(url);
+        Role role = Role.createFromRoleClassUrl(baseUrl + roleUrl);
         assertNotNull(role);
         assertEquals(baseUrl, role.getBaseUrl());
+        assertEquals(baseUrl + roleUrl, role.toRoleClassURL());
     }
 
     /**
-     * Roleのコンストラクタのテスト(URLがbaseURLまでしか設定されていない).
-     * @throws MalformedURLException URLパースエラー
+     * createFromRoleClassUrl when nonRoleUrl given should throw MalformedURLException.
+     * @throws MalformedURLException
      */
     @Test(expected = MalformedURLException.class)
-    public void testRoleConstructWithBaseUrl() throws MalformedURLException {
+    public void createFromRoleClassUrl_nonRoleUrl() throws MalformedURLException {
         String baseUrl = "https://localhost:8080/personium-core/testcell1/";
         String roleUrl = "";
-        URL url = new URL(baseUrl + roleUrl);
-        new Role(url);
+        Role.createFromRoleClassUrl(baseUrl + roleUrl);
     }
 
     /**
-     * Roleのコンストラクタのテスト(URLに"__role"までしかない).
-     * @throws MalformedURLException URLパースエラー
+     * createFromRoleClassUrl when given RoleInstanceUrl should throw MalformedURLException.
+     * @throws MalformedURLException
      */
     @Test(expected = MalformedURLException.class)
-    public void testRoleConstructWithUnderbar() throws MalformedURLException {
+    public void createFromRoleClassUrl_RoleInstanceUrl() throws MalformedURLException {
         String baseUrl = "https://localhost:8080/personium-core/testcell1/";
-        String roleUrl = "__role";
-        URL url = new URL(baseUrl + roleUrl);
-        new Role(url);
+        String roleUrl = "__role/bx/hoge";
+        Role.createFromRoleClassUrl(baseUrl + roleUrl);
     }
 
     /**
@@ -74,8 +72,7 @@ public class RoleTest {
     public void testRoleConstructWithBox() throws MalformedURLException {
         String baseUrl = "https://localhost:8080/personium-core/testcell1/";
         String roleUrl = "__role/__";
-        URL url = new URL(baseUrl + roleUrl);
-        new Role(url);
+        Role.createFromRoleClassUrl(baseUrl + roleUrl);
     }
 
     /**
@@ -85,8 +82,7 @@ public class RoleTest {
     @Test(expected = MalformedURLException.class)
     public void testRoleConstructWithBadURL() throws MalformedURLException {
         String baseUrl = "BadURL";
-        URL url = new URL(baseUrl);
-        new Role(url);
+        Role.createFromRoleInstanceUrl(baseUrl);
     }
 
 }

--- a/src/test/java/io/personium/common/auth/token/TokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/TokenTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
@@ -107,13 +106,19 @@ public class TokenTest {
     public void testVisitorRefreshToken() throws MalformedURLException {
         String base = "https://localhost:8080/personium-core/testcell1/__role/__/";
         List<Role> roleList = new ArrayList<Role>();
-        roleList.add(new Role(new URL(base + "admin")));
-        roleList.add(new Role(new URL(base + "staff")));
-        roleList.add(new Role(new URL(base + "doctor")));
+        roleList.add(Role.createFromRoleClassUrl(base + "admin"));
+        roleList.add(Role.createFromRoleClassUrl(base + "staff"));
+        roleList.add(Role.createFromRoleClassUrl(base + "doctor"));
 
         String id = "1234";
-        VisitorRefreshToken token = new VisitorRefreshToken(id, "http://receiver.com/rcv",
-                "http://orig.com/orig/#subj", "http://orig.com/orig", roleList, "http://schema.com/schema", null);
+        VisitorRefreshToken token = new VisitorRefreshToken(id, new Date().getTime(),
+                AbstractOAuth2Token.REFRESH_TOKEN_EXPIRES_MILLISECS,
+                "http://receiver.com/rcv",
+                "http://orig.com/orig/#subj",
+                "http://orig.com/orig",
+                roleList,
+                "http://schema.com/schema",
+                null);
         String tokenStr = token.toTokenString();
 
         VisitorRefreshToken token2 = null;
@@ -131,19 +136,22 @@ public class TokenTest {
      * @throws TokenParseException TokenParseException
      * @throws TokenRootCrtException TokenRootCrtException
      * @throws TokenDsigException TokenDsigException
+     * @throws MalformedURLException
      */
     @Test
-    public void testTransCellAccessToken() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+    public void testTransCellAccessToken() throws TokenParseException, TokenDsigException, TokenRootCrtException, MalformedURLException {
         String cellRootUrl = "https://localhost/TranscellAccessTokenTestCell/";
         String target = "https://example.com/targetCell/";
         String schema = "https://example.com/schemaCell/";
 
+        String base = cellRootUrl + "__role/__/";
         List<Role> roleList = new ArrayList<Role>();
-        roleList.add(new Role("admin"));
-        roleList.add(new Role("staff"));
-        roleList.add(new Role("doctor"));
+        roleList.add(Role.createFromRoleClassUrl(base + "admin"));
+        roleList.add(Role.createFromRoleClassUrl(base + "staff"));
+        roleList.add(Role.createFromRoleClassUrl(base + "doctor"));
 
-        TransCellAccessToken tcToken = new TransCellAccessToken(cellRootUrl, cellRootUrl + "#admin", target, roleList,
+        TransCellAccessToken tcToken = new TransCellAccessToken(
+                cellRootUrl, cellRootUrl + "#admin", target, roleList,
                 schema, new String[] {"someScope"});
 
         String token = tcToken.toTokenString();
@@ -154,8 +162,8 @@ public class TokenTest {
         for (Role role : roleList) {
             boolean hit = false;
             for (Role role2 : tcToken2.getRoleList()) {
-                String roleUrl = role.schemeCreateUrl(cellRootUrl);
-                if (roleUrl.equals(role2.createUrl())) {
+                String roleUrl = role.toRoleClassURL();
+                if (roleUrl.equals(role2.toRoleClassURL())) {
                     hit = true;
                 }
             }
@@ -171,9 +179,9 @@ public class TokenTest {
     public void testCellLocalAccessToken() throws MalformedURLException, TokenParseException {
         String base = "https://localhost:8080/personium-core/testcell1/__role/__/";
         List<Role> roleList = new ArrayList<Role>();
-        roleList.add(new Role(new URL(base + "admin")));
-        roleList.add(new Role(new URL(base + "staff")));
-        roleList.add(new Role(new URL(base + "doctor")));
+        roleList.add(Role.createFromRoleClassUrl(base + "admin"));
+        roleList.add(Role.createFromRoleClassUrl(base + "staff"));
+        roleList.add(Role.createFromRoleClassUrl(base + "doctor"));
 
         VisitorLocalAccessToken token = new VisitorLocalAccessToken(
                 new Date().getTime(),

--- a/src/test/java/io/personium/common/auth/token/TokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/TokenTest.java
@@ -153,7 +153,7 @@ public class TokenTest {
 
         for (Role role : roleList) {
             boolean hit = false;
-            for (Role role2 : tcToken2.getRoles()) {
+            for (Role role2 : tcToken2.getRoleList()) {
                 String roleUrl = role.schemeCreateUrl(cellRootUrl);
                 if (roleUrl.equals(role2.createUrl())) {
                     hit = true;

--- a/src/test/java/io/personium/common/auth/token/TransCellAccessTokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/TransCellAccessTokenTest.java
@@ -3,8 +3,6 @@ package io.personium.common.auth.token;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
@@ -16,6 +14,7 @@ import java.util.Set;
 
 import javax.naming.InvalidNameException;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,12 +32,8 @@ public class TransCellAccessTokenTest {
     static List<Role> ROLE_LIST = new ArrayList<>();
     static Set<String> SCOPE_SET = new HashSet<>();
     static {
-        try {
-            ROLE_LIST.add(new Role(new URL("https://schema.localhost/__role/__/role1")));
-            ROLE_LIST.add(new Role(new URL("https://schema.localhost/__role/__/role2")));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        ROLE_LIST.add(new Role("role1", "box", "https://schema.localhost/", "https://schema.localhost/"));
+        ROLE_LIST.add(new Role("role2", "box", "https://schema.localhost/", "https://subject.localhost/"));
     }
 
     TransCellAccessToken token;
@@ -69,25 +64,31 @@ public class TransCellAccessTokenTest {
     }
 
     @Test
-    public void testParse_issuer_subject_schema() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+    public void parse_ParsedIssuerSubjectSchema_ShouldBe_SameAs_Original() throws TokenParseException, TokenDsigException, TokenRootCrtException {
         String tokenStr = this.token.toTokenString();
-        TransCellAccessToken token2 = TransCellAccessToken.parse(tokenStr);
-        assertEquals(ISSUER, token2.getIssuer());
-        assertEquals(SUBJECT, token2.getSubject());
-        assertEquals(SCHEMA, token2.getSchema());
+        // parse the prepared token
+        TransCellAccessToken parsedToken = TransCellAccessToken.parse(tokenStr);
+        // Parsed contents are the kept.
+        assertEquals(ISSUER, parsedToken.getIssuer());
+        assertEquals(SUBJECT, parsedToken.getSubject());
+        assertEquals(SCHEMA, parsedToken.getSchema());
+        assertEquals(TARGET, parsedToken.getTarget());
     }
     @Test
-    public void testParse_scopes() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+    public void parse_ParsedScopes_ShouldBe_SameAs_Original() throws TokenParseException, TokenDsigException, TokenRootCrtException {
         String tokenStr = this.token.toTokenString();
-        TransCellAccessToken token2 = TransCellAccessToken.parse(tokenStr);
-        assertEquals(SCOPE.length, token2.getScope().length);
+        // parse the prepared token
+        TransCellAccessToken parsedToken = TransCellAccessToken.parse(tokenStr);
+        // Parsed scopes are kept the same.
+        assertEquals(StringUtils.join(SCOPE, " "), StringUtils.join(parsedToken.getScope(), " "));
     }
 
     @Test
-    public void testParse_roles() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+    public void parse_ParsedRoles_ShouldBe_SameAs_Original() throws TokenParseException, TokenDsigException, TokenRootCrtException {
         String tokenStr = this.token.toTokenString();
-        TransCellAccessToken token2 = TransCellAccessToken.parse(tokenStr);
-        List<Role> parsedRoles = token2.getRoleList();
+        TransCellAccessToken parsedToken = TransCellAccessToken.parse(tokenStr);
+        List<Role> parsedRoles = parsedToken.getRoleList();
+        // Parsed roles should be kept the same.
         assertEquals(ROLE_LIST.size(), parsedRoles.size());
         StringBuilder sb1 = new StringBuilder();
         for (Role role : ROLE_LIST) {
@@ -103,9 +104,7 @@ public class TransCellAccessTokenTest {
     }
 
     @Test
-    public void print() throws TokenParseException, TokenDsigException, TokenRootCrtException {
+    public void toSamlString_Should_Work() throws TokenParseException, TokenDsigException, TokenRootCrtException {
         System.out.println(this.token.toSamlString());
     }
-
-
 }

--- a/src/test/java/io/personium/common/auth/token/TransCellAccessTokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/TransCellAccessTokenTest.java
@@ -102,9 +102,4 @@ public class TransCellAccessTokenTest {
         }
         assertEquals(sb1.toString(), sb2.toString());
     }
-
-    @Test
-    public void toSamlString_Should_Work() throws TokenParseException, TokenDsigException, TokenRootCrtException {
-        System.out.println(this.token.toSamlString());
-    }
 }

--- a/src/test/java/io/personium/common/auth/token/VisitorRefreshTokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/VisitorRefreshTokenTest.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2014 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014 - 2019 Personium Project Authors
+ *  - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,84 +19,118 @@ package io.personium.common.auth.token;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Unit Test class for CellLocalRefreshToken.
+ * Unit Test class for VisitorRefreshTokenTest.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({VisitorRefreshToken.class})
-@PowerMockIgnore({ "javax.xml.crypto.dsig.*", "javax.security.auth.*" })
 public class VisitorRefreshTokenTest {
+    static Logger log = LoggerFactory.getLogger(VisitorRefreshTokenTest.class);
+
+    static final Long ISSUED_AT = new Date().getTime();
+    static final Long LIFESPAN = AbstractOAuth2Token.ACCESS_TOKEN_EXPIRES_MILLISECS;
+
+    static final String ISSUER = "https://issuer.localhost/";
+    static final String SUBJECT = "https://subject.localhost/#acc";
+    static String TARGET = "https://target.localhost/";
+    static String SCHEMA = "https://schema.localhost/";
+    static String[] SCOPE = new String[] {"auth", "message-read"};
+    static List<Role> ROLE_LIST = new ArrayList<>();
+    static Set<String> SCOPE_SET = new HashSet<>();
+    static {
+        ROLE_LIST.add(new Role("role1", "box", "https://schema.localhost/", "https://schema.localhost/"));
+        ROLE_LIST.add(new Role("role2", "box", "https://schema.localhost/", "https://subject.localhost/"));
+    }
+
 
     /** Target class of unit test. */
-    private VisitorRefreshToken transCellRefreshToken;
+    private VisitorRefreshToken visitorRefreshToken;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AbstractLocalToken.setKeyString("a123456789abcdef");
+    }
 
     /**
      * Before.
      */
     @Before
-    public void befor() {
-        transCellRefreshToken = PowerMockito.spy(new VisitorRefreshToken(null, null, null, null, null, null, null));
+    public void before() {
+        visitorRefreshToken = new VisitorRefreshToken(
+                "12345",
+                ISSUED_AT,
+                LIFESPAN,
+                ISSUER,
+                SUBJECT,
+                ISSUER,
+                ROLE_LIST,
+                SCHEMA,
+                SCOPE);
     }
 
     /**
      * Test refreshAccessToken().
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void refreshAccessToken_Normal() {
         // --------------------
         // Test method args
         // --------------------
-        long issuedAt = 1L;
-        String target = "https://personium/targetcell/";
-        String cellUrl = "https://personium/testcell/";
-        List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
-        roleList.add(role);
+//        long issuedAt = 1L;
+//        String target = "https://personium/targetcell/";
+//        String cellUrl = "https://personium/testcell/";
+//        List<Role> roleList = new ArrayList<>();
+//        Role role = new Role("roleName");
+//        roleList.add(role);
 
         // --------------------
         // Mock settings
         // --------------------
-        IAccessToken ret = new ResidentLocalAccessToken(1L, null, null, null, null);
-        ArgumentCaptor<Long> issuedAtCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<String> targetCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> cellUrlCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<List> roleListCaptor = ArgumentCaptor.forClass(List.class);
-        PowerMockito.doReturn(ret).when(transCellRefreshToken).refreshAccessToken(
-                issuedAtCaptor.capture(), targetCaptor.capture(), cellUrlCaptor.capture(),
-                roleListCaptor.capture());
+
+//        IAccessToken ret = new ResidentLocalAccessToken(1L, null, null, null, null);
+//        ArgumentCaptor<Long> issuedAtCaptor = ArgumentCaptor.forClass(Long.class);
+//        ArgumentCaptor<String> targetCaptor = ArgumentCaptor.forClass(String.class);
+//        ArgumentCaptor<String> cellUrlCaptor = ArgumentCaptor.forClass(String.class);
+//        ArgumentCaptor<List> roleListCaptor = ArgumentCaptor.forClass(List.class);
+//        Mockito.doReturn(ret).when(visitorRefreshToken).refreshAccessToken(
+//                issuedAtCaptor.capture(), targetCaptor.capture(), cellUrlCaptor.capture(),
+//                roleListCaptor.capture());
 
         // --------------------
         // Expected result
         // --------------------
         // Nothing.
+        Long refreshedAt = ISSUED_AT + LIFESPAN * 2;
 
         // --------------------
         // Run method
         // --------------------
-        transCellRefreshToken.refreshAccessToken(issuedAt, target, cellUrl, roleList);
+        VisitorLocalAccessToken at = (VisitorLocalAccessToken)visitorRefreshToken
+                .refreshAccessToken(refreshedAt, LIFESPAN, null, ISSUER, ROLE_LIST);
 
         // --------------------
         // Confirm result
         // --------------------
-        assertThat(issuedAtCaptor.getValue(), is(issuedAt));
-        assertThat(targetCaptor.getValue(), is(target));
-        assertThat(cellUrlCaptor.getValue(), is(cellUrl));
-        assertThat(roleListCaptor.getValue(), is(roleList));
+        assertEquals(refreshedAt, Long.valueOf(at.issuedAt));
+        assertEquals(ISSUER, at.getIssuer());
+        assertEquals(SUBJECT, at.getSubject());
+        assertEquals(SCHEMA, at.getSchema());
+        assertTrue(Arrays.deepEquals(ROLE_LIST.toArray(), at.getRoleList().toArray()));
     }
 
     /**
@@ -105,47 +140,28 @@ public class VisitorRefreshTokenTest {
      */
     @Test
     public void refreshAccessToken_Normal_schema_is_null_target_is_null() {
-        transCellRefreshToken = PowerMockito.spy(new VisitorRefreshToken(
-                null, null, "https://personium/subject/", null, null, "https://personium/schema/", null));
         // --------------------
         // Test method args
         // --------------------
-        long issuedAt = 1L;
-        String target = null;
-        String cellUrl = "https://personium/testcell02/";
-        List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
-        roleList.add(role);
 
-        // --------------------
-        // Mock settings
-        // --------------------
-        // Nothing.
 
-        // --------------------
-        // Expected result
-        // --------------------
-        Long expectedIssuedAt = issuedAt;
-        String expectedIssuer = cellUrl;
-        String expectedSubject = "https://personium/subject/";
-        List<Role> expectedRoleList = roleList;
-        String expectedSchema = "https://personium/schema/";
+        Long refreshedAt = ISSUED_AT + LIFESPAN * 2;
 
         // --------------------
         // Run method
         // --------------------
-        IAccessToken actual = transCellRefreshToken.refreshAccessToken(issuedAt, target, cellUrl, roleList);
+        IAccessToken actual = visitorRefreshToken.refreshAccessToken(refreshedAt, LIFESPAN, null, ISSUER, ROLE_LIST);
 
         // --------------------
         // Confirm result
         // --------------------
         assertThat(actual, instanceOf(VisitorLocalAccessToken.class));
         VisitorLocalAccessToken castActual = (VisitorLocalAccessToken) actual;
-        assertThat(castActual.issuedAt, is(expectedIssuedAt));
-        assertThat(castActual.getIssuer(), is(expectedIssuer));
-        assertThat(castActual.getSubject(), is(expectedSubject));
-        assertThat(castActual.getRoleList(), is(expectedRoleList));
-        assertThat(castActual.getSchema(), is(expectedSchema));
+        assertEquals(refreshedAt, Long.valueOf(castActual.issuedAt));
+        assertEquals(ISSUER, castActual.getIssuer());
+        assertEquals(SUBJECT, castActual.getSubject());
+        assertEquals(SCHEMA, castActual.getSchema());
+        assertTrue(Arrays.deepEquals(ROLE_LIST.toArray(), castActual.getRoleList().toArray()));
     }
 
     /**
@@ -159,17 +175,17 @@ public class VisitorRefreshTokenTest {
         // --------------------
         // Test method args
         // --------------------
-        long issuedAt = 1L;
-        String subject = "https://personium/subject/";
-        String target = "https://personium/targetcell/";
-        String cellUrl = "https://personium/testcell02/";
-        List<Role> roleList = new ArrayList<>();
-        Role role = new Role("roleName");
-        roleList.add(role);
-        String schema = "https://personium/appcell/";
+//        long issuedAt = 1L;
+//        String subject = "https://personium/subject/";
+//        String target = "https://personium/targetcell/";
+//        String cellUrl = "https://personium/testcell02/";
+//        List<Role> roleList = new ArrayList<>();
+//        Role role = new Role("roleName");
+//        roleList.add(role);
+//        String schema = "https://personium/appcell/";
 
-        transCellRefreshToken = PowerMockito.spy(new VisitorRefreshToken(
-                null, null, subject, null, null, schema, null));
+//        visitorRefreshToken = new VisitorRefreshToken(
+//                null, null, subject, null, null, schema, null);
 
         // X509 settings.
         String folderPath = "x509/effective/";
@@ -188,28 +204,54 @@ public class VisitorRefreshTokenTest {
         // --------------------
         // Expected result
         // --------------------
-        Long expectedIssuedAt = issuedAt;
-        String expectedIssuer = cellUrl;
-        String expectedTarget = target;
-        List<Role> expectedRoleList = roleList;
-        String expectedSchema = schema;
-        String expectedSubject = subject;
+        Long refreshedAt = ISSUED_AT + LIFESPAN * 2;
 
         // --------------------
         // Run method
         // --------------------
-        IAccessToken actual = transCellRefreshToken.refreshAccessToken(issuedAt, target, cellUrl, roleList);
+        IAccessToken actual = visitorRefreshToken.refreshAccessToken(refreshedAt,LIFESPAN, TARGET, ISSUER, ROLE_LIST);
 
         // --------------------
         // Confirm result
         // --------------------
         assertThat(actual, instanceOf(TransCellAccessToken.class));
         TransCellAccessToken castActual = (TransCellAccessToken) actual;
-        assertThat(castActual.issuedAt, is(expectedIssuedAt));
-        assertThat(castActual.getIssuer(), is(expectedIssuer));
-        assertThat(castActual.getSubject(), is(expectedSubject));
-        assertThat(castActual.getTarget(), is(expectedTarget));
-        assertThat(castActual.getRoleList(), is(expectedRoleList));
-        assertThat(castActual.getSchema(), is(expectedSchema));
+        assertThat(castActual.issuedAt, is(refreshedAt));
+        assertThat(castActual.getIssuer(), is(ISSUER));
+        assertThat(castActual.getSubject(), is(SUBJECT));
+        assertThat(castActual.getTarget(), is(TARGET));
+        assertThat(castActual.getRoleList(), is(ROLE_LIST));
+        assertThat(castActual.getSchema(), is(SCHEMA));
+    }
+    @Test
+    public void parse_ParsedRoles_ShouldBe_SameAs_Original() throws Exception {
+        VisitorRefreshToken vrt = new VisitorRefreshToken(
+                "12345",
+                new Date().getTime(),
+                AbstractOAuth2Token.ACCESS_TOKEN_EXPIRES_MILLISECS,
+                ISSUER,
+                SUBJECT,
+                ISSUER,
+                ROLE_LIST,
+                SCHEMA,
+                SCOPE);
+        String tokenStr = vrt.toTokenString();
+        VisitorRefreshToken parsedToken = VisitorRefreshToken.parse(tokenStr, ISSUER);
+        List<Role> parsedRoles = parsedToken.getRoleList();
+        // Parsed roles should be kept the same.
+        assertEquals(ROLE_LIST.size(), parsedRoles.size());
+        StringBuilder sb1 = new StringBuilder();
+        for (Role role : ROLE_LIST) {
+            sb1.append(role.toRoleClassURL());
+            sb1.append(" ");
+        }
+        StringBuilder sb2 = new StringBuilder();
+        for (Role role : parsedRoles) {
+            sb2.append(role.toRoleClassURL());
+            sb2.append(" ");
+        }
+        log.info(sb1.toString());
+        log.info(sb2.toString());
+        assertEquals(sb1.toString(), sb2.toString());
     }
 }

--- a/src/test/java/io/personium/common/auth/token/VisitorRefreshTokenTest.java
+++ b/src/test/java/io/personium/common/auth/token/VisitorRefreshTokenTest.java
@@ -144,7 +144,7 @@ public class VisitorRefreshTokenTest {
         assertThat(castActual.issuedAt, is(expectedIssuedAt));
         assertThat(castActual.getIssuer(), is(expectedIssuer));
         assertThat(castActual.getSubject(), is(expectedSubject));
-        assertThat(castActual.getRoles(), is(expectedRoleList));
+        assertThat(castActual.getRoleList(), is(expectedRoleList));
         assertThat(castActual.getSchema(), is(expectedSchema));
     }
 

--- a/src/test/java/io/personium/common/auth/token/X509KeySelecterTest.java
+++ b/src/test/java/io/personium/common/auth/token/X509KeySelecterTest.java
@@ -54,9 +54,9 @@ public class X509KeySelecterTest {
      */
     @BeforeClass
     public static void beforeClass() {
-        roleList.add(new Role("admin"));
-        roleList.add(new Role("staff"));
-        roleList.add(new Role("doctor"));
+        roleList.add(new Role("admin", null, null, cellRootUrl));
+        roleList.add(new Role("staff", null, null, cellRootUrl));
+        roleList.add(new Role("doctor", null, null, cellRootUrl));
     }
 
     /**


### PR DESCRIPTION
Role Url in tokens should be as follows:

|Token|Role Info| currently |Shoud fix|
|:--|:--|:--|:--|
|TransCellAccessToken|Role Class URL|Role Instance URL|Yes|
|ResidentAccessToken| - | - |No|
|ResidentRefreshToken| - | - |No|
|GrantCode| - | - |No|
|VisitorAccessToken|Role Instance URL|Role Instance URL|No|
|VisitorRefreshToken|Role Class URL|Role Instance URL|Yes|
 
This fix is necessary to fix the following problem of personium-core
https://github.com/personium/personium-core/issues/516

